### PR TITLE
Bugfix: Copying address of a loop variable

### DIFF
--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -131,7 +131,8 @@ func Services(c *kubernetes.Clientset, dc *dynamic.DynamicClient) ([]Service, er
 	for idx, service := range services {
 		for _, deployment := range deploymentsInNamespaces[service.Svc.Namespace] {
 			if k8s.SelectorsMatch(deployment.Spec.Selector.MatchLabels, service.Svc.Spec.Selector) {
-				services[idx].Deployment = &deployment
+				d := deployment
+				services[idx].Deployment = &d
 			}
 		}
 	}


### PR DESCRIPTION
The iteration variables of for range loop are re-used each iteration. It is the same variable and it is re-assigned each iteration, therefore the multiple elements of the deploymentsInNamespace slice referring to the same Deployment object.
The one-liner `d := deployment` fix the problem because the redeclaration creates a new variable each iteration and has the value of iteration variable.