### PR TITLE
Publish OCI artifacts for Flux to continuously deploy Capacitor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required for creating the GitHub release
+      packages: write # Required for pushing to GitHub Container Registry
     steps:
     - name: 🛑 Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.1
@@ -67,3 +70,13 @@ jobs:
         push: true
         tags: |
           ghcr.io/gimlet-io/capacitor:${{ steps.version.outputs.version }}
+    - name: Set up Flux CLI
+      uses: fluxcd/flux2/action@v2.2.3
+    - name: Push manifests
+      run: |
+        flux push artifact \
+        oci://ghcr.io/gimlet-io/capacitor-manifests:${{ steps.version.outputs.version }} \
+        --path=deploy/k8s \
+        --source=${{ github.repositoryUrl }} \
+        --revision="${{ github.ref_name }}@sha1:${{ github.sha }}" \
+        --annotations='org.opencontainers.image.description=Capacitor install manifests for Flux'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,52 @@ A general purpose UI for FluxCD.
 
 ## Installation
 
-### Kubernetes maninfests
+### Flux
+
+Deploy the latest Capacitor release in the `flux-system` namespace
+by adding the following manifests to your Flux repository:
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: capacitor
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: oci://ghcr.io/gimlet-io/capacitor-manifests
+  ref:
+    semver: ">=0.1.0-0"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: capacitor
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  wait: true
+  prune: true
+  path: "./"
+  sourceRef:
+    kind: OCIRepository
+    name: capacitor
+```
+
+Note that Flux will check for Capacitor releases every 12 hours and will 
+automatically deploy the new version if it is available.
+
+Access Capacitor UI with port-forwarding:
+
+```bash
+kubectl -n flux-system port-forward svc/capacitor 9000:9000
+```
+
+### Kubernetes manifests
 
 ```
 kubectl create namespace infrastructure

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - rbac.yaml
+  - manifest.yaml
+patches:
+  - patch: |
+      - op: replace
+        path: "/metadata/labels/app.kubernetes.io~1managed-by"
+        value: Flux
+      - op: remove
+        path: "/metadata/labels/helm.sh~1chart"
+    target:
+      kind: (Deployment|Service)


### PR DESCRIPTION
This PR adds a step to the release workflow to push the install manifests to GHCR. From there, Flux running on clusters can install Capacitor using a Flux `OCIRepository` and Flux `Kustomization`. The readme contains the instructions on how to setup  continuously deployment for Capacitor with Flux.