### PR TITLE
fix: port-forwarding on other than port 9000 now works

### DIFF
--- a/web/src/streamingBackend.js
+++ b/web/src/streamingBackend.js
@@ -6,9 +6,9 @@ if (typeof window !== 'undefined') {
   URL = protocol + '://' + window.location.hostname;
 
   let port = window.location.port
-  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-    port = 9000
-  }
+  // if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+  //   port = 9000
+  // }
   if (port && port !== '') {
     URL = URL + ':' + port
   }


### PR DESCRIPTION
Port forwarding not on port 9000 did not work before this change.

These lines should be only used in local development.