### PR TITLE
BUG: Releases in non-default namespaces not always visible

### DIFF
--- a/pkg/flux/flux.go
+++ b/pkg/flux/flux.go
@@ -297,8 +297,9 @@ func helmStatusWithResources(
 	}
 
 	actionConfig := action.Configuration{}
-	actionConfig.Init(cli.New().RESTClientGetter(), "", "", nil)
-
+	envSettings := cli.New()
+	envSettings.SetNamespace(hr.GetReleaseNamespace())
+	actionConfig.Init(envSettings.RESTClientGetter(), "", "", nil)
 	resources, err := actionConfig.KubeClient.Build(bytes.NewBufferString(release.Manifest), false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I noticed that some but not all pods from releases installed in a namespace other than "default" do not show up in Capacitor.

It turns out that if a release is installed a non-default namespace Capacitor would incorrectly detect the corresponding artifacts as belonging to the "default" namespace unless the chart templates explicitly set the "metadata.namespace" attribtue even though that is not required.

Installing the "podinfo" chart in a non-default namespace is a good way to reproduce this.