### PR TITLE
Account for undefined artifact value

### DIFF
--- a/web/src/HelmChartWidget.jsx
+++ b/web/src/HelmChartWidget.jsx
@@ -5,7 +5,7 @@ export function HelmChartWidget(props) {
 
   const sourceRef = source.spec.sourceRef
   const artifact = source.status.artifact
-  const revision = artifact.revision
+  const revision = artifact?.revision || 'unknown'
 
   const navigationHandler = () => handleNavigationSelect("Sources", source.metadata.namespace, sourceRef.name, sourceRef.kind)
 


### PR DESCRIPTION
Closes https://github.com/gimlet-io/capacitor/issues/90

I believe this is occurring due to the status not having an artifact present, hence the revision is undefined. 