### PR TITLE
fix: sources inconsistencies on https repos url and urls suffixed by .git

### DIFF
--- a/web/src/Kustomization.jsx
+++ b/web/src/Kustomization.jsx
@@ -104,7 +104,7 @@ export function RevisionWidget(props) {
   // const reconcilingCondition = reconcilingConditions.length === 1 ? reconcilingConditions[0] : undefined
   // const reconciling = reconcilingCondition && reconcilingConditions[0].status === "True"
 
-  const url = source.spec.url.slice(source.spec.url.indexOf('@') + 1)
+  const url = source.spec.url.slice(source.spec.url.indexOf('@') + 1).replace(/https?:\/\//g, '').replace(/\.git/g, '')
 
   const navigationHandler = inFooter ?
     () => handleNavigationSelect("Sources", source.metadata.namespace, source.metadata.name, source.kind) :


### PR DESCRIPTION
This PR aims to fix #97 issue by removing https://, http:// and .git from the source spec URL, since in first place https:// is added in a hard-coded way on `Kustomization.jsx:143` and on `Kustomization.jsx:120`, and url's that end on ".git" generate non-working urls for example for commits on gitlab.com.