### PR TITLE
feat: add securityContext defaults to deployment manifest

### DIFF
--- a/deploy/helm/onechart-helm-values.yaml
+++ b/deploy/helm/onechart-helm-values.yaml
@@ -8,3 +8,15 @@ probe:
 resources:
   ignoreLimits: true
 serviceAccount: capacitor
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault

--- a/deploy/k8s/manifest.yaml
+++ b/deploy/k8s/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   name: capacitor
   namespace: flux-system
   labels:
-    helm.sh/chart: onechart-0.63.0
+    helm.sh/chart: onechart-0.69.0
     app.kubernetes.io/name: onechart
     app.kubernetes.io/instance: capacitor
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ metadata:
   name: capacitor
   namespace: flux-system
   labels:
-    helm.sh/chart: onechart-0.63.0
+    helm.sh/chart: onechart-0.69.0
     app.kubernetes.io/name: onechart
     app.kubernetes.io/instance: capacitor
     app.kubernetes.io/managed-by: Helm
@@ -70,7 +70,17 @@ spec:
           requests:
             cpu: 200m
             memory: 200Mi
-        securityContext: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 101
+          runAsNonRoot: true
+          runAsUser: 100
+          seccompProfile:
+            type: RuntimeDefault
       initContainers: null
       securityContext:
         fsGroup: 999


### PR DESCRIPTION
### Fix ?
In it's current form, the installation instructions for capacitor in this repository do not work for clusters that are hardened following pod security best practices and have the [restricted pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) enforced for it's flux-system namespace.

The following error will be thrown by the kubernetes API:

```
'pods "capacitor-XXXXX-XXXX" is forbidden: violates PodSecurity "restricted:latest":
      allowPrivilegeEscalation != false (container "capacitor" must set securityContext.allowPrivilegeEscalation=false),
      unrestricted capabilities (container "capacitor" must set securityContext.capabilities.drop=["ALL"]),
      runAsNonRoot != true (pod or container "capacitor" must set securityContext.runAsNonRoot=true),
      seccompProfile (pod or container "capacitor" must set securityContext.seccompProfile.type
      to "RuntimeDefault" or "Localhost")'
```

### Solution

In a similar fashion to [flux's security documentation](https://fluxcd.io/flux/security/#pod-security-standard) this change makes the capacitor manifests compatible with the standard allowing deployment to a hardened cluster without manual configuration by the enduser.

### What has been done
- The helm values have been updated to include a `securityContext` compatible with the "restricted" PodSecurity standard profile
- The manifests have been re-rendered to include this change