### PR TITLE
fix[ui]: handle properly helm releases that use OCI repo sources

### DIFF
--- a/web/src/HelmRevisionWidget.jsx
+++ b/web/src/HelmRevisionWidget.jsx
@@ -24,7 +24,8 @@ export function HelmRevisionWidget(props) {
   const reconcilingCondition = reconcilingConditions.length === 1 ? reconcilingConditions[0] : undefined
   const reconciling = reconcilingCondition && reconcilingConditions[0].status === "True"
 
-  const sourceRef = helmRelease.spec.chart.spec.sourceRef
+  const sourceRef = helmRelease.spec.chart ? helmRelease.spec.chart.spec.sourceRef : helmRelease.spec.chartRef
+
   const namespace = sourceRef.namespace ? sourceRef.namespace : helmRelease.metadata.namespace
   const navigationHandler = () => handleNavigationSelect("Sources", namespace, sourceRef.name, sourceRef.kind)
 


### PR DESCRIPTION
Hey there! Thanks for your work on Capacitor, really appreciated 🙌 !

Helm Releases have a different structure for chart references when they come from OCI repositories. 

In such cases, currently we get a null pointer exception in the UI as:

`Cannot read properties of undefined (reading 'spec')`

I've tested with this change locally and it seems to work good 👍 