### PR TITLE
Agent addressing issue #151

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,0 +1,16 @@
+# Task
+
+@src/components/resourceList/NodeList.tsx
+@src/components/resourceList/PodList.tsx
+@src/components/resourceList/ResourceList.tsx
+@src/resourceTypeConfigs.tsx
+@src/views/dashboard.tsx
+
+Node status is extracted from the Kubernetes resource state in NodeList.tsx where we define accessors. Extend accessor for nodes to display the common Kubernetes Node states like SchedulingDisabled, Cordoned. A node can have multiple states (look for it) or conditions, like DiskPressure, MemoryPressure. Display them as comma separated list, like kubectl does it on `kubectl get nodes`
+
+## Metadata
+
+- Issue: #151
+- Branch: agent-151-3040982426
+- Amp Thread ID: T-8865d174-de6b-4aa5-a47a-3dc95a7aab3b
+- Created: 2025-07-06T06:10:01Z


### PR DESCRIPTION
This PR is created by an agent to address issue #151.

## Original Issue

feat: status column for nodes in the resource list should show SchedulingDisabled state

## Prompt

@src/components/resourceList/NodeList.tsx
@src/components/resourceList/PodList.tsx
@src/components/resourceList/ResourceList.tsx
@src/resourceTypeConfigs.tsx
@src/views/dashboard.tsx

Node status is extracted from the Kubernetes resource state in NodeList.tsx where we define accessors. Extend accessor for nodes to display the common Kubernetes Node states like SchedulingDisabled, Cordoned. A node can have multiple states (look for it) or conditions, like DiskPressure, MemoryPressure. Display them as comma separated list, like kubectl does it on `kubectl get nodes`

## Metadata

- **Amp Thread ID**: `T-8865d174-de6b-4aa5-a47a-3dc95a7aab3b`
- **Created**: 2025-07-06T06:10:02Z
