### PR TITLE
Agent addressing issue #159

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,0 +1,11 @@
+# Task
+
+@src/components/resourceDetail/LogsViewer.tsx
+There is a previous logs feature in the logs viewer component. I'd like you to move it from being a checkbox toggle, to be an option in the History dropdown. Right bellow the "All logs" option. Name it "Previous logs".
+
+## Metadata
+
+- Issue: #159
+- Branch: agent-159-3045567865
+- Amp Thread ID: T-5ce53f87-f72b-4886-a02b-34d80fd78684
+- Created: 2025-07-07T15:10:41Z


### PR DESCRIPTION
This PR is created by an agent to address issue #159.

## Original Issue

chore: move the previous log toggle into the history dropdown

## Prompt

@src/components/resourceDetail/LogsViewer.tsx
There is a previous logs feature in the logs viewer component. I'd like you to move it from being a checkbox toggle, to be an option in the History dropdown. Right bellow the "All logs" option. Name it "Previous logs".

## Metadata

- **Amp Thread ID**: `T-5ce53f87-f72b-4886-a02b-34d80fd78684`
- **Created**: 2025-07-07T15:10:42Z
