### PR TITLE
[Agent] feat: back and forward button for filters

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,0 +1,17 @@
+# Task
+
+@src/components/filterBar/FilterBar.tsx
+@src/store/filterStore.tsx
+@public/styles/main.css
+
+We are able to set different filters in the filter bar.
+- We should maintain the history of previous filters and I would like to go back and forth between previous filters.
+- A left and right arrow button in the filterbar should manage this, this button group should stick to the right edge of the bar
+- A keyboard shortcut should be associated to these buttons: ctrl+left arrow and ctrl+right arrow. Don't forget to use the common visual representation of the shortcuts.
+
+## Metadata
+
+- Issue: #157
+- Branch: agent-157-3045778298
+- Amp Thread ID: T-d0e89d78-bff5-42fe-826d-0b5333e0002d
+- Created: 2025-07-07T16:17:39Z


### PR DESCRIPTION
This PR is created by an agent to address issue #157.

## Original Issue

feat: back and forward button for filters

## Prompt

@src/components/filterBar/FilterBar.tsx
@src/store/filterStore.tsx
@public/styles/main.css

We are able to set different filters in the filter bar.
- We should maintain the history of previous filters and I would like to go back and forth between previous filters.
- A left and right arrow button in the filterbar should manage this, this button group should stick to the right edge of the bar
- A keyboard shortcut should be associated to these buttons: ctrl+left arrow and ctrl+right arrow. Don't forget to use the common visual representation of the shortcuts.

## Metadata

- **Amp Thread ID**: `T-d0e89d78-bff5-42fe-826d-0b5333e0002d`
- **Created**: 2025-07-07T16:17:40Z
