### PR TITLE
[Agent] feat: exec into pod

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,0 +1,12 @@
+# Task
+
+Add a new tab to @src/components/resourceDetail/ResourceDrawer.tsx call it "Exec". It is only available for pods, on ctrl+e command shortcut.
+
+When the tab is active, you should start an interactive shell session in it, like one would do with `kubectl exec -it <podname>`. Try starting sh, ash or bash if available. The tab should show a terminal emulator in the browser.
+
+## Metadata
+
+- Issue: #172
+- Branch: agent-172-3083911979
+- Amp Thread ID: T-3b42e359-7435-48c1-a943-3b89d5cca959
+- Created: 2025-07-17T12:37:45Z


### PR DESCRIPTION
This PR is created by an agent to address issue #172.

## Original Issue

feat: exec into pod

## Prompt

Add a new tab to @src/components/resourceDetail/ResourceDrawer.tsx call it "Exec". It is only available for pods, on ctrl+e command shortcut.

When the tab is active, you should start an interactive shell session in it, like one would do with `kubectl exec -it <podname>`. Try starting sh, ash or bash if available. The tab should show a terminal emulator in the browser.

## Metadata

- **Amp Thread ID**: `T-3b42e359-7435-48c1-a943-3b89d5cca959`
- **Created**: 2025-07-17T12:37:47Z
