### PR TITLE
fix: Follow theme and kubeconfig aware when switching context

### DIFF
--- a/cli/pkg/kubernetes/client.go
+++ b/cli/pkg/kubernetes/client.go
@@ -167,7 +167,7 @@ func (c *Client) GetContexts() []ContextInfo {
 }
 
 // SwitchContext switches to a different Kubernetes context
-func (c *Client) SwitchContext(contextName string) error {
+func (c *Client) SwitchContext(contextName, kubeConfigPath string) error {
 	// Check if the context exists
 	ctx, exists := c.AvailableContexts[contextName]
 	if !exists {
@@ -179,23 +179,13 @@ func (c *Client) SwitchContext(contextName string) error {
 		return fmt.Errorf("cannot switch context when running in-cluster")
 	}
 
-	// Find kubeconfig path
-	kubeconfig := ""
-	if os.Getenv("KUBECONFIG") != "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-	} else if home := homedir.HomeDir(); home != "" {
-		kubeconfig = filepath.Join(home, ".kube", "config")
-	} else {
-		return fmt.Errorf("kubeconfig not found")
-	}
-
 	// Create config with new context
 	configOverrides := &clientcmd.ConfigOverrides{
 		CurrentContext: contextName,
 	}
 
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeConfigPath},
 		configOverrides,
 	)
 

--- a/cli/pkg/kubernetes/client.go
+++ b/cli/pkg/kubernetes/client.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"

--- a/cli/pkg/server/server.go
+++ b/cli/pkg/server/server.go
@@ -169,7 +169,7 @@ func (s *Server) Setup() {
 		}
 
 		// Switch context
-		err := s.k8sClient.SwitchContext(req.Context)
+		err := s.k8sClient.SwitchContext(req.Context, s.Config.KubeConfigPath)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
 				"error": fmt.Sprintf("Failed to switch context: %v", err),

--- a/cli/pkg/server/server.go
+++ b/cli/pkg/server/server.go
@@ -169,7 +169,7 @@ func (s *Server) Setup() {
 		}
 
 		// Switch context
-		err := s.k8sClient.SwitchContext(req.Context, s.Config.KubeConfigPath)
+		err := s.k8sClient.SwitchContext(req.Context, s.config.KubeConfigPath)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
 				"error": fmt.Sprintf("Failed to switch context: %v", err),

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -2051,15 +2051,16 @@ td.message-cell {
 
 /* Conditions YAML section */
 .conditions-yaml {
-  background-color: #f8f9fa;
+  background-color: var(--linear-bg);
   border-radius: 4px;
   padding: 12px;
   margin: 8px 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.9rem;
+  color: var(--linear-text-primary);
   white-space: pre-wrap;
   overflow-x: auto;
-  border: 1px solid #dee2e6;
+  border: 1px solid var(--linear-border);
   max-height: 300px;
 }
 

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -210,7 +210,7 @@ h1 {
 
 .events-list {
   margin-top: 2rem;
-  background-color: #f8f9fa;
+  background-color: var(--linear-bg-secondary);
   border-radius: 4px;
 }
 
@@ -253,34 +253,34 @@ h1 {
 }
 
 .event-reason {
-  color: #495057;
+  color: var(--linear-text-primary);
   font-size: 0.9rem;
 }
 
 .event-count {
-  color: #6c757d;
+  color: var(--linear-text-secondary);
   font-size: 0.8rem;
 }
 
 .event-object {
-  color: #495057;
+  color: var(--linear-text-primary);
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
 }
 
 .event-message {
-  color: #212529;
+  color: var(--linear-text-tertiary);
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
 }
 
 .event-timestamp {
-  color: #6c757d;
+  color: var(--linear-text-secondary);
   font-size: 0.8rem;
 }
 
 .events-truncated {
-  color: #6c757d;
+  color: var(--linear-text-secondary);
   font-size: 0.8rem;
   text-align: center;
   padding: 0.5rem;


### PR DESCRIPTION
Hi there!

First of all, big big thanks for this project - simple yet amazing to use and have a GUI nonetheless :D

I've noticed two locations where the theme was not followed while testing the new version today:
* The first one is that the conditions YAML section didn't follow the theme
* The second one is that the events section didn't follow the theme as well

For the events I've got screenshots of the changes:

| Before | After |
| --- | --- |
| <img width="736" height="429" alt="image" src="https://github.com/user-attachments/assets/0e743bc4-722e-41e2-887f-0eed42d3b8da" /> | <img width="747" height="425" alt="image" src="https://github.com/user-attachments/assets/07ed8670-a391-4a80-99e8-37770244d583" /> |

There *may or may not* be other locations as well, to be honest I haven't looked everywhere.

---

The other thing I've noticed it that when giving a custom kubeconfig path with the `--kubeconfig` CLI argument and then switching the contexts with the UI, it always used the default path and didn't use the one in the config of the server itself that is set when using the CLI argument.

I've made it so that the kubeconfig file when switching the context is taken from the `Server`'s `config` field, though that does remove the support for the `KUBECONFIG` environment variable. That logic however, is not in the the other functions, for example:

https://github.com/gimlet-io/capacitor/blob/163eca8211321398bf8f39e69cf7cbaa5a71d4a7/cli/pkg/config/config.go#L79-L85

https://github.com/gimlet-io/capacitor/blob/163eca8211321398bf8f39e69cf7cbaa5a71d4a7/cli/pkg/kubernetes/client.go#L43-L49

It can be added back obviously, but then it would make sense to have it everywhere.

---

Hope that helps on improving the project! Don't hesitate to throw suggestions to the changes :)