### PR TITLE
fix: handle context names with forward slashes (EKS ARNs)

### DIFF
--- a/cli/pkg/server/k8s_proxy.go
+++ b/cli/pkg/server/k8s_proxy.go
@@ -112,23 +112,14 @@ func NewKubernetesProxy(k8sClient *kubernetes.Client) (*KubernetesProxy, error) 
 
 // HandleAPIRequest handles a Kubernetes API request
 func (p *KubernetesProxy) HandleAPIRequest(c echo.Context) error {
-	// Get path from request
-	path := c.Request().URL.Path
-
-	// Strip /k8s/:context prefix
-	if after, ok := strings.CutPrefix(path, "/k8s/"); ok {
-		// Remove the context segment (up to next '/')
-		// Expect formats: /k8s/<context>/..., or /k8s
-		slash := strings.IndexByte(after, '/')
-		if slash >= 0 {
-			path = after[slash:]
-		} else {
-			// No trailing path; forward to root
-			path = "/"
-		}
-	}
-
-	// Update the path
+	// Echo's wildcard param (*) captures everything after /k8s/:context/
+	// This is the Kubernetes API path we want to proxy
+	apiPath := c.Param("*")
+	
+	// Prepend slash to make it an absolute path
+	path := "/" + apiPath
+	
+	// Update the request path
 	c.Request().URL.Path = path
 
 	// Log the proxied request (optional, might want to disable for production)


### PR DESCRIPTION
# Bug: Capacitor fails with EKS context names containing forward slashes

## Description
Capacitor Next fails to proxy Kubernetes API requests when using AWS EKS clusters, because EKS uses full ARN names as contexts which contain forward slashes.

## Example Context Name
```
arn:aws:eks:eu-central-1:123456789012:cluster/my-eks-cluster
```

## Error Observed
- Browser console shows: `Failed to fetch namespaces: 404 Not Found - 404 page not found`
- Server logs show successful status 200 but with 0 bytes returned
- API requests to `/k8s/<context>/api/v1/namespaces` return 404

## Root Cause
In `cli/pkg/server/k8s_proxy.go`, the `HandleAPIRequest` function uses `strings.IndexByte(after, '/')` to find the first forward slash to strip the context from the path. However, when the context name itself contains forward slashes (like EKS ARNs), it finds the FIRST slash which is actually INSIDE the context name, not after it.

**Current broken code:**
```go
// Strip /k8s/:context prefix
if after, ok := strings.CutPrefix(path, "/k8s/"); ok {
    slash := strings.IndexByte(after, '/')  // ❌ Finds slash INSIDE the ARN!
    if slash >= 0 {
        path = after[slash:]
    }
}
```

## Proposed Fix
Use Echo's wildcard parameter `*` which automatically captures everything after `/k8s/:context/`:

```go
// HandleAPIRequest handles a Kubernetes API request
func (p *KubernetesProxy) HandleAPIRequest(c echo.Context) error {
    // Echo's wildcard param (*) captures everything after /k8s/:context/
    // This is the Kubernetes API path we want to proxy
    apiPath := c.Param("*")
    
    // Prepend slash to make it an absolute path
    path := "/" + apiPath
    
    // Update the request path
    c.Request().URL.Path = path

    // Log the proxied request
    log.Printf("Proxying request: %s %s", c.Request().Method, path)

    // Proxy the request
    p.proxy.ServeHTTP(c.Response().Writer, c.Request())

    return nil
}
```

## Testing
After the fix:
```bash
# This now works correctly
curl "http://localhost:3333/k8s/arn%3Aaws%3Aeks%3Aeu-central-1%3A123456789012%3Acluster%2Fmy-eks-cluster/api/v1/namespaces"
```

Returns actual namespace data instead of 404.

## Impact
This affects all users using:
- AWS EKS clusters (uses ARN format)
- Any Kubernetes context names containing forward slashes
- Potentially other cloud providers with similar naming schemes

## Related Issues
- #257 - Fixed `@` character encoding (but not forward slashes)
- PR #259 - Added URL decoding for context parameter