### PR TITLE
fix: kubevirt subresources don't have verbs => broke everything

### DIFF
--- a/src/store/apiResourceStore.tsx
+++ b/src/store/apiResourceStore.tsx
@@ -190,6 +190,7 @@ export function ApiResourceProvider(props: { children: JSX.Element }) {
       // Filter to include only resources that support listing (have 'list' in verbs)
       // and aren't subresources (don't contain '/')
       const filteredResources = allApiResources.filter(resource => 
+        resource.verbs && // kubevirt subresources don't have verbs
         resource.verbs.includes('list') && 
         !resource.name.includes('/') &&
         resource.kind // Ensure it has a kind


### PR DESCRIPTION
Fixes #293 

<img width="895" height="468" alt="image" src="https://github.com/user-attachments/assets/6c04088e-e5f1-42e1-aeb4-d7d140c3c1b4" />
