### PR TITLE
feat: add support for extraVolumes and extraVolumeMounts

### DIFF
--- a/self-host/charts/capacitor-next/templates/deployment.yaml
+++ b/self-host/charts/capacitor-next/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
             - name: registry
               mountPath: /app/backend/registry.yaml
               subPath: registry.yaml
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: registry
           secret:
@@ -65,6 +68,9 @@ spec:
             items:
               - key: registry.yaml
                 path: registry.yaml
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/self-host/charts/capacitor-next/values.yaml
+++ b/self-host/charts/capacitor-next/values.yaml
@@ -136,6 +136,27 @@ tolerations: []
 # Affinity
 affinity: {}
 
+# Extra volumes
+extraVolumes: []
+  # - name: config-volume
+  #   configMap:
+  #     name: special-config
+  # - name: cache-volume
+  #   emptyDir: {}
+  # - name: data-volume
+  #   persistentVolumeClaim:
+  #     claimName: my-pvc
+
+# Extra volume mounts
+extraVolumeMounts: []
+  # - name: config-volume
+  #   mountPath: /etc/config
+  #   readOnly: true
+  # - name: cache-volume
+  #   mountPath: /var/cache
+  # - name: data-volume
+  #   mountPath: /data
+
 # Existing secret configuration
 # If specified, the deployment will use this secret in addition to the built-in secret
 # Both secrets will be loaded via envFrom, allowing you to override or supplement values


### PR DESCRIPTION
This change adds support for extraVolumes and extraVolumeMounts to allow users to mount additional volumes to the deployment.

This is useful for mounting configuration files, custom CA certificates, secrets, or persistent storage that are not part of the default chart configuration.

Changes:
- Added extraVolumes field in values.yaml with examples
- Added extraVolumeMounts field in values.yaml with examples
- Modified deployment.yaml to render extraVolumes using toYaml and with
- Modified deployment.yaml to render extraVolumeMounts using toYaml and with

Tested it mounting a custom CA cert and setting SSL_CERT_FILE via existingSecret. Changed insecureSkipTlsVerify from true to false and everything works without any TLS errors.