### PR TITLE
feat: Make FluxCD controller configuration configurable via environment variables

### DIFF
--- a/src/config/fluxcd.ts
+++ b/src/config/fluxcd.ts
@@ -1,0 +1,31 @@
+/**
+ * FluxCD Controller Configuration
+ * 
+ * Supports custom FluxCD installations via environment variables.
+ * All values have sensible defaults for standard FluxCD installations.
+ * 
+ * Environment variables:
+ * - FLUXCD_NAMESPACE: FluxCD namespace (default: "fluxcd-system")
+ * - FLUXCD_HELM_CONTROLLER_NAME: Helm controller deployment name
+ * - FLUXCD_HELM_CONTROLLER_LABEL_KEY: Helm controller label selector key
+ * - FLUXCD_HELM_CONTROLLER_LABEL_VALUE: Helm controller label selector value
+ * - FLUXCD_KUSTOMIZE_CONTROLLER_NAME: Kustomize controller deployment name
+ * - FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_KEY: Kustomize controller label selector key
+ * - FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_VALUE: Kustomize controller label selector value
+ */
+
+export const fluxcdConfig = {
+  namespace: Deno.env.get("FLUXCD_NAMESPACE") || "fluxcd-system",
+  
+  helmController: {
+    deploymentName: Deno.env.get("FLUXCD_HELM_CONTROLLER_NAME") || "fluxcd-helm-controller",
+    labelKey: Deno.env.get("FLUXCD_HELM_CONTROLLER_LABEL_KEY") || "app.kubernetes.io/component",
+    labelValue: Deno.env.get("FLUXCD_HELM_CONTROLLER_LABEL_VALUE") || "helm-controller",
+  },
+  
+  kustomizeController: {
+    deploymentName: Deno.env.get("FLUXCD_KUSTOMIZE_CONTROLLER_NAME") || "fluxcd-kustomize-controller",
+    labelKey: Deno.env.get("FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_KEY") || "app.kubernetes.io/component",
+    labelValue: Deno.env.get("FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_VALUE") || "kustomize-controller",
+  },
+} as const;

--- a/src/views/helmReleaseDetails.tsx
+++ b/src/views/helmReleaseDetails.tsx
@@ -26,6 +26,7 @@ import { HelmManifestDiff } from "../components/resourceDetail/HelmManifestDiff.
 import { HelmHistory } from "../components/resourceDetail/HelmHistory.tsx";
 import { ConditionType } from "../utils/conditions.ts";
 import { LogsViewer } from "../components/resourceDetail/LogsViewer.tsx";
+import { fluxcdConfig } from "../config/fluxcd.ts";
 
 export function HelmReleaseDetails() {
   const params = useParams();
@@ -840,14 +841,23 @@ export function HelmReleaseDetails() {
         />
       </Show>
 
-      {/* Logs Tab - helm-controller in flux-system */}
+      {/* Logs Tab - helm-controller */}
       <Show when={activeMainTab() === "logs"}>
         <LogsViewer
           resource={{
             apiVersion: "apps/v1",
             kind: "Deployment",
-            metadata: { name: "helm-controller", namespace: "flux-system" },
-            spec: { selector: { matchLabels: { "app": "helm-controller" } } }
+            metadata: { 
+              name: fluxcdConfig.helmController.deploymentName, 
+              namespace: fluxcdConfig.namespace 
+            },
+            spec: { 
+              selector: { 
+                matchLabels: { 
+                  [fluxcdConfig.helmController.labelKey]: fluxcdConfig.helmController.labelValue 
+                } 
+              } 
+            }
           }}
           isOpen={activeMainTab() === "logs"}
           initialSearch={(helmRelease()?.spec?.releaseName || helmRelease()?.metadata.name) as string}

--- a/src/views/kustomizationDetails.tsx
+++ b/src/views/kustomizationDetails.tsx
@@ -28,6 +28,7 @@ import type { Event } from "../types/k8s.ts";
 import { EventList } from "../components/resourceList/EventList.tsx";
 import { ConditionType } from "../utils/conditions.ts";
 import { LogsViewer } from "../components/resourceDetail/LogsViewer.tsx";
+import { fluxcdConfig } from "../config/fluxcd.ts";
 
 // Utility function to parse inventory entry ID and extract resource info
 interface InventoryResourceInfo {
@@ -1353,8 +1354,17 @@ export function KustomizationDetails() {
                   resource={{
                     apiVersion: "apps/v1",
                     kind: "Deployment",
-                    metadata: { name: "kustomize-controller", namespace: "flux-system" },
-                    spec: { selector: { matchLabels: { "app": "kustomize-controller" } } }
+                    metadata: { 
+                      name: fluxcdConfig.kustomizeController.deploymentName, 
+                      namespace: fluxcdConfig.namespace 
+                    },
+                    spec: { 
+                      selector: { 
+                        matchLabels: { 
+                          [fluxcdConfig.kustomizeController.labelKey]: fluxcdConfig.kustomizeController.labelValue 
+                        } 
+                      } 
+                    }
                   }}
                   isOpen={activeMainTab() === "logs"}
                   initialSearch={(kustomization()?.metadata.name) as string}


### PR DESCRIPTION
fixes: https://github.com/gimlet-io/capacitor/issues/315

the PR makes FluxCD controller deployment names and label selectors configurable via environment variables, supporting custom FluxCD installations while maintaining backward compatibility with standard setups.

as an example 

FLUXCD_NAMESPACE=fluxcd-system \
FLUXCD_HELM_CONTROLLER_NAME=fluxcd-helm-controller \
FLUXCD_HELM_CONTROLLER_LABEL_KEY=app.kubernetes.io/component \
FLUXCD_HELM_CONTROLLER_LABEL_VALUE=helm-controller \
FLUXCD_KUSTOMIZE_CONTROLLER_NAME=fluxcd-kustomize-controller \
FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_KEY=app.kubernetes.io/component \
FLUXCD_KUSTOMIZE_CONTROLLER_LABEL_VALUE=kustomize-controller ./capacitor-darwin-arm64