### PR TITLE
fix(docs): broken link

### DIFF
--- a/docs/docs/markdown/self-host.md
+++ b/docs/docs/markdown/self-host.md
@@ -37,7 +37,7 @@ There are various options to deploy Capacitor Next bellow. Regardless of what in
 
 ### OCIArtifact
 
-- [Kustomization and OCIArtifact](https://github.com/gimlet-io/capacitor/tree/main/self-host/yaml/README.md)
+- [Kustomization and OCIArtifact](https://github.com/gimlet-io/capacitor/tree/main/self-host/yaml/capacitor-next/README.md)
 
 
 ### Plain yaml


### PR DESCRIPTION
Fix the broken link to the README for installation via OCIArtifact.