### PR TITLE
fix(cli): use localhost for browser URL on macOS

### DIFF
--- a/cli/cmd/main.go
+++ b/cli/cmd/main.go
@@ -97,7 +97,11 @@ func main() {
 	log.Printf("WebSocket endpoint available at ws://%s:%d/ws", cfg.Address, cfg.Port)
 
 	// Open browser
-	serverURL := fmt.Sprintf("http://%s:%d", cfg.Address, cfg.Port)
+	browserHost := cfg.Address
+	if browserHost == "0.0.0.0" {
+		browserHost = "localhost"
+	}
+	serverURL := fmt.Sprintf("http://%s:%d", browserHost, cfg.Port)
 	log.Printf("Opening browser at %s", serverURL)
 	if err := openBrowser(serverURL); err != nil {
 		log.Printf("Warning: Could not open browser: %v", err)


### PR DESCRIPTION
When listening on 0.0.0.0, the browser was opened with that address which macOS open command doesn't handle properly. Now uses localhost for the browser URL when the listen address is 0.0.0.0.