### PR TITLE
fix: eliminate race condition in multi-context k8s client creation

### DIFF
--- a/cli/cmd/main.go
+++ b/cli/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// Create Kubernetes client
 	log.Println("Creating Kubernetes client...")
-	k8sClient, err := kubernetes.NewClient(cfg.KubeConfigPath, cfg.InsecureSkipTLSVerify)
+	k8sClient, err := kubernetes.NewClient(cfg.KubeConfigPath, cfg.InsecureSkipTLSVerify, "")
 	if err != nil {
 		log.Fatalf("Error creating Kubernetes client: %v", err)
 	}

--- a/cli/pkg/kubernetes/watch.go
+++ b/cli/pkg/kubernetes/watch.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 
@@ -62,14 +63,14 @@ func (w *ResourceWatcher) WatchResource(ctx context.Context, path string, events
 	// Execute request
 	resp, err := w.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error executing watch request: %w", err)
+		return fmt.Errorf("error executing watch request for path %s: %w", path, err)
 	}
 	defer resp.Body.Close()
 
 	// Check response status
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("watch request failed with status %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("watch request failed for path %s with status %d: %s", path, resp.StatusCode, string(body))
 	}
 
 	// Process the response stream
@@ -99,11 +100,12 @@ func (w *ResourceWatcher) createWatchRequest(path string) (*http.Request, error)
 
 	// Combine the base URL with the path
 	fullURL := w.client.Config.Host + path
+	log.Printf("Watch request: context=%s url=%s", w.client.CurrentContext, fullURL)
 
 	// Create request
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
+		return nil, fmt.Errorf("error creating request for path %s: %w", path, err)
 	}
 
 	// Set up authentication

--- a/cli/pkg/server/ws_handler.go
+++ b/cli/pkg/server/ws_handler.go
@@ -237,8 +237,11 @@ func (h *WebSocketHandler) handleSubscribe(
 				}
 				return // Context was cancelled, expected
 			}
-			log.Printf("Error watching resource: %v", err)
-			h.sendErrorMessage(ws, msg.ID, msg.Path, fmt.Sprintf("error watching resource: %v", err))
+			log.Printf("Error watching resource [context=%s path=%s]: %v",
+				h.k8sClient.CurrentContext, msg.Path, err)
+			h.sendErrorMessage(ws, msg.ID, msg.Path,
+				fmt.Sprintf("error watching resource [context=%s]: %v",
+					h.k8sClient.CurrentContext, err))
 			delete(watchContextsForConn, key)
 			delete(watchIdsForConn, msg.ID)
 		}
@@ -510,7 +513,6 @@ func (h *WebSocketHandler) handleHelmHistoryWatch(ctx context.Context, ws *wsuti
 
 		// Get initial state
 		history, err := h.helmClient.GetHistory(ctx, releaseName, namespace)
-
 		if err != nil {
 			log.Printf("Error getting Helm release history: %v", err)
 			h.sendErrorMessage(ws, msg.ID, msg.Path, fmt.Sprintf("Failed to get Helm release history: %v", err))

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -2777,9 +2777,21 @@ td.message-cell {
 
 .error-message {
   font-weight: 500;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   line-height: 1.5;
   font-size: 14px;
+}
+
+.error-path {
+  font-size: 12px;
+  margin-bottom: 0.5rem;
+  opacity: 0.85;
+}
+
+.error-path code {
+  background: rgba(0, 0, 0, 0.1);
+  padding: 1px 4px;
+  border-radius: 2px;
 }
 
 .error-timestamp {

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -23,6 +23,11 @@ export function ErrorDisplay(props: ErrorDisplayProps) {
             <div class="error-container">            
               <div class="error-content">
                 <div class="error-message">{error().message}</div>
+                <Show when={error().path}>
+                  <div class="error-path">
+                    <small>Path: <code>{error().path}</code></small>
+                  </div>
+                </Show>
                 <div class="error-timestamp">
                   <small>Error occurred at {formatTimestamp(error().timestamp)}</small>
                 </div>


### PR DESCRIPTION
NewClient() now accepts a contextName parameter to create clients with
the correct context from construction, removing the need for mutable
SwitchContext() calls in getOrCreateK8sProxyForContext().

This fixes intermittent 404s for valid API endpoints (e.g. /api/v1/pods)
caused by concurrent SwitchContext() calls mutating shared Config.Host
and Clientset fields.

Also adds double-checked locking in the proxy cache to prevent duplicate
client creation, improves error messages with context/path info, and
displays the error path in the frontend ErrorDisplay component.
