### PR TITLE
feat(capacitor-next): add Gateway API HTTPRoute support

### DIFF
--- a/self-host/charts/capacitor-next/templates/httproute.yaml
+++ b/self-host/charts/capacitor-next/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: {{ .Values.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ .Values.httpRoute.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "capacitor-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "capacitor-server.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+      {{- if .Values.httpRoute.matches }}
+        {{- toYaml .Values.httpRoute.matches | nindent 8 }}
+      {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+      {{- end }}
+      backendRefs:
+        - name: {{ include "capacitor-server.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/self-host/charts/capacitor-next/values.yaml
+++ b/self-host/charts/capacitor-next/values.yaml
@@ -176,6 +176,23 @@ ingress:
   #    hosts:
   #      - capacitor.example.com
 
+## HTTPRoute configuration
+httpRoute:
+  # -- Enables Gateway API HTTPRoute resource generation instead of standard Ingress
+  enabled: false
+  # -- HTTPRoute apiVersion. Keep this configurable for environments that need a non-default Gateway API version
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- HTTPRoute kind
+  kind: HTTPRoute
+  # -- Key-value map for controller-specific metadata
+  annotations: {}
+  # -- FQDNs for Layer 7 hostname matching. If empty, the route matches all hostnames allowed by the parent Gateway listener
+  hostnames: []
+  # -- References to the parent Gateway listeners this route should attach to
+  parentRefs: []
+  # -- Match rules applied before the default PathPrefix "/" fallback
+  matches: []
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary

This PR adds native Gateway API `HTTPRoute` support to the `capacitor-next` Helm chart.

The chart already supports standard `Ingress`, but there was no built-in way to generate an `HTTPRoute`. This made Gateway API deployments require manual resources outside the chart. With Kubernetes `v1.36.0` recently released, adding first-class `HTTPRoute` support makes the chart easier to use in modern Gateway API based clusters.

Closes #384.

## What changed

This PR adds:

- a new `templates/httproute.yaml`
- a new `httpRoute` configuration block in `values.yaml`
- configurable `apiVersion` and `kind`
- support for:
  - `annotations`
  - `hostnames`
  - `parentRefs`
  - `matches`
- a default `PathPrefix: /` route when no custom matches are provided

The implementation keeps `Ingress` support unchanged by default and only renders an `HTTPRoute` when `httpRoute.enabled=true`.

## Example configuration

```yaml
ingress:
  enabled: false

httpRoute:
  enabled: true
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  hostnames:
    - capacitor-next.cluster.local
  parentRefs:
    - name: internal-gateway
      namespace: gateway-system
      sectionName: capacitor-next-cluster-local
```

## Example Gateway listener

```yaml
- name: capacitor-next-cluster-local
  hostname: capacitor-next.cluster.local
  port: 443
  protocol: HTTPS
  tls:
    mode: Terminate
    certificateRefs:
      - kind: Secret
        name: capacitor-next-tls
  allowedRoutes:
    namespaces:
      from: Selector
      selector:
        matchLabels:
          kubernetes.io/metadata.name: flux-system
    kinds:
      - kind: HTTPRoute
      - kind: GRPCRoute
```

## Validation

This was validated with:

- `helm lint`
- `helm template`
- a real deployment in a cluster using Cilium Gateway API
- successful routing through `Gateway -> HTTPRoute -> Service -> Pod`

## Environment note for Cilium 1.19.3

In the test environment, Cilium `v1.19.3` also required the experimental `TLSRoute` CRD because the operator expected `gateway.networking.k8s.io/v1alpha2` for `TLSRoute`.

The required command was:

```bash
kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
```

This is an environment-specific requirement and is not part of the chart change itself.

## Deployment note

In the test environment, `capacitor-next` was deployed in `flux-system`, which already had restrictive `NetworkPolicy` objects. The chart change itself worked correctly, but traffic from the Gateway only succeeded after allowing ingress to the `capacitor-next` pods on port `8080`.

Example policy used in that environment:

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-capacitor-next-http
  namespace: flux-system
spec:
  podSelector:
    matchLabels:
      app: capacitor-next
      app.kubernetes.io/instance: capacitor-next
      app.kubernetes.io/name: capacitor-next
  policyTypes:
    - Ingress
  ingress:
    - ports:
        - protocol: TCP
          port: 8080
```

This is an environment-specific operational note, not a required chart change.

## Why this approach

The implementation follows the same pattern used successfully in other charts:

- render the `HTTPRoute` only when explicitly enabled
- keep configuration minimal and backward compatible
- bind the route to the chart `Service`
- avoid changing existing `Ingress` behavior unless the user opts in

## Backward compatibility

- No change for existing users unless `httpRoute.enabled=true`
- Existing `Ingress` users are unaffected
- The new feature is opt-in
